### PR TITLE
fix invalid license designation format

### DIFF
--- a/package/metadata.json
+++ b/package/metadata.json
@@ -14,7 +14,7 @@
         "Category": "Online Services",
         "Icon": "gmailfeed",
         "Id": "org.kde.plasma.gmailfeed",
-        "License": "GPL3",
+        "License": "GPL-3.0+",
         "Version": "2.0",
         "Website": "https://github.com/anthon38/gmailfeed",
         "EnabledByDefault": true


### PR DESCRIPTION
appstream-cli has begun to error from this, so here's the fix we're using in Debian (and all derivatives: Ubuntu, etc.)