### PR TITLE
replace PlasmaComponents with QtQuick.Controls in config UI files

### DIFF
--- a/package/contents/ui/configAccounts.qml
+++ b/package/contents/ui/configAccounts.qml
@@ -19,7 +19,7 @@
 
 import QtQuick
 import QtQuick.Layouts
-import org.kde.plasma.components as PlasmaComponents
+import QtQuick.Controls
 import org.kde.kcmutils // KCMLauncher
 import org.kde.plasma.private.gmailfeed
 
@@ -45,11 +45,11 @@ SimpleKCM {
 
     RowLayout {
 
-        PlasmaComponents.Label {
+        Label {
             text: i18n("Current account: ")
         }
 
-        PlasmaComponents.ComboBox {
+        ComboBox {
             id: comboBox
 
             model: accountsModel
@@ -61,7 +61,7 @@ SimpleKCM {
             Layout.fillWidth: true
         }
 
-        PlasmaComponents.Button {
+        Button {
 
             icon.name: "applications-internet"
             text: i18n("Manage accounts...")

--- a/package/contents/ui/configGeneral.qml
+++ b/package/contents/ui/configGeneral.qml
@@ -19,7 +19,7 @@
 
 import QtQuick
 import QtQuick.Layouts
-import org.kde.plasma.components as PlasmaComponents
+import QtQuick.Controls
 import org.kde.kcmutils
 
 SimpleKCM {
@@ -28,11 +28,11 @@ SimpleKCM {
     property alias cfg_pollinterval: spinbox.value
 
     RowLayout {
-        PlasmaComponents.Label {
+        Label {
             text: i18n("Polling interval: ")
         }
 
-        PlasmaComponents.SpinBox {
+        SpinBox {
             id: spinbox
             from: 1
             to: 90


### PR DESCRIPTION
config qml files should not use plasma themed widgets but the regular ones, otherwise it looks like that:

![Screenshot_20250208_004640](https://github.com/user-attachments/assets/96286364-2dd6-4fc9-9f9c-e09b9a45da93)
